### PR TITLE
Added convert option to skip compilation.

### DIFF
--- a/bin/pyxie
+++ b/bin/pyxie
@@ -72,6 +72,7 @@ def show_help():
     pyxie codegen filename -- parses, analyse and generate code for the given filename, outputs result to console. Does not attempt compiling
     pyxie [--profile arduino] compile path/to/filename.suffix -- compiles the given file to path/to/filename
     pyxie [--profile arduino] compile path/to/filename.suffix  path/to/other/filename -- compiles the given file to the destination filename
+    pyxie [--profile arduino] convert path/to/filename.suffix -- converts the python code to a cpp build folde but does not compile
 """)
 
 

--- a/pyxie/api.py
+++ b/pyxie/api.py
@@ -80,6 +80,7 @@ import pyxie.parsing.context
 from pyxie.core import parse_file
 from pyxie.core import analyse_file
 from pyxie.core import compile_file
+from pyxie.core import convert_file
 from pyxie.core import codegen_phase
 from pyxie.core import compilation_tests
 from pyxie.core import compile_testfile
@@ -170,6 +171,11 @@ class StandardOptions(CommandLineDispatcher):
     def compile(filename, result_filename=None):
         """compiles the given file to path/to/filename -- result_filename can be provide an alternative output name"""
         compile_file(filename, profile, result_filename)
+    
+    @staticmethod
+    def convert(filename, result_filename=None):
+        """converts the given file to cpp code but does not compile"""
+        convert_file(filename, profile, result_filename)
 
 
 def initialise_API(profile_name):

--- a/pyxie/core.py
+++ b/pyxie/core.py
@@ -273,6 +273,39 @@ def build_program(source, work_dir, name, profile):
     print("build_program: Done!")
     print()
 
+# Just complete the build process and produce source files without compiling
+def convert_file(filename, profile, result_filename=None):
+
+    build_env = get_build_environment(filename, result_filename)
+
+    rootdir = build_env["rootdir"]
+    base_dir = build_env["base_dir"]
+    base_filename = build_env["base_filename"]
+    cname = build_env["cname"]
+    result_filename = build_env["result_filename"]
+
+    c_code  = codegen_phase(filename, result_filename, profile)
+
+    c_code = code_header + c_code
+
+    print("C_CODE:::", repr(c_code))
+    print("compile_file: COMPILING", filename)
+    print("compile_file: IN", base_dir)
+    print("compile_file: SOURCEFILE", base_filename)
+    print("compile_file: cname", cname)
+    print("compile_file: result_filename", result_filename)
+
+    build_dir = os.path.join(base_dir, cname)
+    try:
+        os.mkdir(build_dir)
+    except OSError as e:
+       if e.errno != 17: # Directory exists
+           raise
+
+    build_program(c_code, build_dir, cname, profile)
+
+    os.chdir(rootdir)
+    return
 
 # Next function is called by compile_file, but could be called independently
 # This is why both do "build_env", rather that expect the caller to


### PR DESCRIPTION
This will still create all the files unlike pure codegen.
e.g
```
pyxie [--profile arduino] convert path/to/filename.suffix -- converts the python code to a cpp build folde but does not compile
pyxie --profile arduino convert sample.py
```